### PR TITLE
Replace section with React fragment in AnimatedFlight

### DIFF
--- a/components/animated-flight.tsx
+++ b/components/animated-flight.tsx
@@ -11,7 +11,7 @@ export default function AnimatedFlight({ planeSrc, cloudsSrc }: { planeSrc: stri
   }
 
   return (
-    <section className="relative overflow-hidden py-0" style={sectionStyle}>
+  
       {/* overlay to soften background */}
       <div className="absolute inset-0 bg-white/40 pointer-events-none -z-10" />
 
@@ -69,6 +69,6 @@ export default function AnimatedFlight({ planeSrc, cloudsSrc }: { planeSrc: stri
 
       {/* subtle bottom gradient */}
       <div className="absolute inset-x-0 bottom-0 h-36 bg-gradient-to-t from-white to-transparent pointer-events-none" />
-    </section>
+   
   )
 }

--- a/components/animated-flight.tsx
+++ b/components/animated-flight.tsx
@@ -11,7 +11,7 @@ export default function AnimatedFlight({ planeSrc, cloudsSrc }: { planeSrc: stri
   }
 
   return (
-  
+  <>
       {/* overlay to soften background */}
       <div className="absolute inset-0 bg-white/40 pointer-events-none -z-10" />
 
@@ -69,6 +69,6 @@ export default function AnimatedFlight({ planeSrc, cloudsSrc }: { planeSrc: stri
 
       {/* subtle bottom gradient */}
       <div className="absolute inset-x-0 bottom-0 h-36 bg-gradient-to-t from-white to-transparent pointer-events-none" />
-   
+   </>
   )
 }


### PR DESCRIPTION
## Changes Made

- Replaced `<section>` element with React fragment (`<>...</>`) in the AnimatedFlight component
- Removed the `className="relative overflow-hidden py-0"` and `style={sectionStyle}` attributes that were applied to the section element

## Files Modified

- `components/animated-flight.tsx`

The component now returns its content wrapped in a React fragment instead of a styled section element.To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 3`

🔗 [Edit in Builder.io](https://builder.io/app/projects/1ef7e63f115d4aed810631a68303cc1c/zenith-realm)

👀 [Preview Link](https://1ef7e63f115d4aed810631a68303cc1c-zenith-realm.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>1ef7e63f115d4aed810631a68303cc1c</projectId>-->
<!--<branchName>zenith-realm</branchName>-->